### PR TITLE
Remove obsolete dist-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,15 @@ that improves on a few of `pacman`'s lousy ergonomics.
 
 `pa` is not strictly MSYS2-only,
 but it is developed to be used specifically in MSYS2.
-In particular, it includes the `dist-upgrade` command
-that safely upgrades the MSYS2 runtime.
 
 ## Usage
 
-`pa` has five commands, each mapping directly to some invocation of `pacman`:
+`pa` has four commands, each mapping directly to some invocation of `pacman`:
 
 * `install <package>` to install `<package>`
 * `remove <package>` to remove `<package>`
 * `search <pattern>` to search for `<pattern>` in a `pacman` mirror
-* `dist-upgrade` to perform a system upgrade
-* `upgrade` to upgrade all packages
+* `upgrade` to upgrade either the core system or all userland packages
 
 `pa` has a simple completion of its own
 and additionally delegates to the official `pacman` completion, if available.

--- a/_pa
+++ b/_pa
@@ -11,7 +11,7 @@ _pa()
             . $dist_completion && _pacman
         fi 
     else
-        COMPREPLY=($(compgen -W 'install search remove dist-upgrade upgrade' -- "$cur"))
+        COMPREPLY=($(compgen -W 'install search remove upgrade' -- "$cur"))
     fi
 
 } &&

--- a/pa
+++ b/pa
@@ -14,10 +14,6 @@ for arg in "$@"; do
             shift
             pacman --color=auto -R "$@"
             ;;
-        dist-upgrade)
-            shift
-            update-core
-            ;;
         upgrade)
             shift
             pacman --color=auto -Syu "$@"


### PR DESCRIPTION
The MSYS2 `pacman` fork modified `--sysupgrade` to first update core
packages, then other packages iff no core packages were upgraded, and
removed the now redundant `update-core` script [1]. This changes the
update procedure from

``` sh
$ update-core
# restart MSYS2
$ pacman -Syu
```

to

``` sh
$ pacman -Syu
# restart MSYS2
$ pacman -Syu
```

The change both breaks and obsoletes the `dist-upgrade` command. Rather
than fixing it, remove it entirely.

[1] Alexpux/MSYS2-pacman#26
